### PR TITLE
use dedicated github secrets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,11 +24,12 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-east-1
-          aws-access-key-id: ${{ secrets.DEVEX_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DEVEX_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.CI_PUBLIC_REPOS_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_PUBLIC_REPOS_AWS_SECRET_ACCESS_KEY }}
       - name: ECR Login
         uses: aws-actions/amazon-ecr-login@v1
         with:
           registry-type: public
+          mask-password: true
       - name: Build & Push
         run: make docker-build docker-push IMG=${AWS_ECR_REPO}/${APP_NAME} TAG=${GITHUB_REF_NAME}


### PR DESCRIPTION
* use dedicated github secrets 
* avoid warning in [build action](https://github.com/aws-actions/amazon-ecr-login#docker-credentials)  