### PR TITLE
fix memory aliasing lints in tests

### DIFF
--- a/pkg/aws/ami_test.go
+++ b/pkg/aws/ami_test.go
@@ -91,6 +91,8 @@ func TestIsLastAmiOldEnough(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		fmt.Printf("test: %s\n", test.name)
 		awsSsm := testSsm{
 			OutputGetParameter: &test.mockedOutputGetParameterSsm,

--- a/pkg/aws/clusters_test.go
+++ b/pkg/aws/clusters_test.go
@@ -47,6 +47,8 @@ func TestGetClusters(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		fmt.Printf("test: %s\n", test.name)
 		awsEks := testEks{OutputListClusters: &test.mockedOutput}
 

--- a/pkg/aws/nodegroups_test.go
+++ b/pkg/aws/nodegroups_test.go
@@ -49,6 +49,8 @@ func TestGetNodegroupsFromCluster(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		fmt.Printf("test: %s\n", test.name)
 		awsEks := testEks{OutputListNodegroups: &test.mockedOutput}
 

--- a/pkg/aws/regions_test.go
+++ b/pkg/aws/regions_test.go
@@ -63,6 +63,8 @@ func TestGetRegionsToCheck(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		fmt.Printf("test: %s\n", test.name)
 		awsEc2 := testEc2{Output: &test.mockedOutput}
 		regionsVar := test.regionsVar


### PR DESCRIPTION
Saw these show up here https://github.com/loomhq/eks-ng-ami-updater/actions/runs/6087525872/job/16516271317